### PR TITLE
asmecher/hypothesis#10: Modify delivery of pdfJsViewer template to use hypothes.is version of pdf.js

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pdf.js"]
+	path = pdf.js
+	url = https://github.com/hypothesis/pdf.js-hypothes.is.git

--- a/HypothesisPlugin.inc.php
+++ b/HypothesisPlugin.inc.php
@@ -27,6 +27,7 @@ class HypothesisPlugin extends GenericPlugin {
 	function register($category, $path) {
 		if (parent::register($category, $path)) {
 			HookRegistry::register('ArticleHandler::download',array(&$this, 'callback'));
+			HookRegistry::register('TemplateManager::display', array(&$this, 'callbackTemplateDisplay'));
 			return true;
 		}
 		return false;
@@ -47,6 +48,33 @@ class HypothesisPlugin extends GenericPlugin {
 		});
 
 		return false;
+	}
+
+	/**
+	 * Hook callback function for TemplateManager::display
+	 * @param $hookName string
+	 * @param $args array
+	 * @return boolean
+	 */
+	function callbackTemplateDisplay($hookName, $args) {
+		if ($hookName != 'TemplateManager::display') return false;
+		$templateMgr = $args[0];
+		$template = $args[1];
+		if ($template == 'plugins-plugins-generic-pdfJsViewer-generic-pdfJsViewer:articleGalley.tpl') {
+			$templateMgr->registerFilter("output", array($this, 'changePdfjsPath'));
+		}
+		return false;
+	}
+
+	/**
+	 * Output filter to create a new element in a registration form
+	 * @param $output string
+	 * @param $templateMgr TemplateManager
+	 * @return $string
+	 */
+	function changePdfjsPath($output, $templateMgr) {
+		$newOutput = str_replace('pdfJsViewer/pdf.js/web/viewer.html?file=', 'hypothesis/pdf.js/viewer/web/viewer.html?file=', $output);
+		return $newOutput;
 	}
 
 	/**

--- a/README
+++ b/README
@@ -18,7 +18,7 @@ COPYING for the complete terms of this license.
 
 System Requirements
 -------------------
-This plugin has been developed for OJS 3.0.x and may not work with other
+This plugin has been developed for OJS 3.1.2 and may not work with other
 versions.
 
 Installation
@@ -34,17 +34,8 @@ If you cannot use the Plugin Gallery, you can also install the plugin as follows
  - Read an HTML article in the public reader interface of OJS and verify that
    the Hypothes.is tool is embedded.
 
-In order to support Hypothes.is with OJS's PDF.js-based PDF reader, you'll need
-to apply a patch to the version of PDF.js that's included in that plugin. The
-patch is currently available at:
-
-https://github.com/hypothesis/pdf.js-hypothes.is/commit/ab3f25
-
-To apply it...
-
-    cd plugins/generic/pdfJsViewer/pdf.js
-    patch -p2 < /path/to/ab3f25.diff
-
+In order to support Hypothes.is with OJS's PDF.js-based PDF reader, this plugin
+hijacks the template display of the pdfJsViewer plugin.
 
 Contact/Support
 ---------------


### PR DESCRIPTION
Use `TemplateManager::display` hook for replace the path to pdf.js from "pdfJsViewer" to this plugin.

'cause ain't nobody got time for `patch`.